### PR TITLE
スマートフォンでのインクリメンタルサーチをする際のUX向上

### DIFF
--- a/app/assets/javascripts/search_sheets.js
+++ b/app/assets/javascripts/search_sheets.js
@@ -212,7 +212,9 @@ $(document).on('turbolinks:load', function () {
     sheet_search_with_asynchronous_communiation()
   })
 
-  $('.sheet_search_form').on('keyup', function () {
+  $('.sheet_search_form').on('keyup　compositionend', function () {
+
+    console.log("searched");
 
     // 検索実行のタイマーが起動済みの時はリセットする
     clearTimeout(search_sheets_timer);
@@ -222,4 +224,5 @@ $(document).on('turbolinks:load', function () {
       sheet_search_with_asynchronous_communiation()
     }, 500);
   });
+
 });

--- a/app/assets/javascripts/search_users.js
+++ b/app/assets/javascripts/search_users.js
@@ -97,7 +97,7 @@ $(document).on('turbolinks:load', function () {
     });
   }
 
-  $(".input_user_name").on("keyup", function () {
+  $(".input_user_name").on("keyup　compositionend", function () {
 
     // 検索実行のタイマーが起動済みの時はリセットする
     clearTimeout(search_name_timer);


### PR DESCRIPTION
# What
スマートフォンでインクリメンタルサーチをする際に、変換や予測でもサーチが
行えるようにする。

# Why
現在の仕様ではカタカナへ変換してもひらがなで検索しただけで止まってしまうので、
変換や予測変換でもサーチが行えるようにすることでUXの向上を図る。