### PR TITLE
URLにパラメーターを直接指定した時のリダイレクトの設定

### DIFF
--- a/app/controllers/sheets_controller.rb
+++ b/app/controllers/sheets_controller.rb
@@ -11,8 +11,13 @@ class SheetsController < ApplicationController
   end
 
   def show 
-    @sheet = Sheet.find(params[:id])
-    @item = Item.where(sheet_id: @sheet.id).order('top ASC')
+    if Sheet.find_by(id: params[:id])
+      @sheet = Sheet.find(params[:id])
+      @item = Item.where(sheet_id: @sheet.id).order('top ASC')
+      redirect_to user_path(current_user.id) if @sheet.users.first.id!=current_user.id
+    else
+      redirect_to user_path(current_user.id)
+    end
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :move_to_index
+  before_action :move_to_show, except: :index
 
   def index
     @users = User.where('name LIKE(?)',"%#{params[:keyword]}%")
@@ -57,7 +57,7 @@ class UsersController < ApplicationController
 
   private
 
-  def move_to_index
-    redirect_to root_path unless user_signed_in?
+  def move_to_show
+    redirect_to user_path(current_user.id) if params[:id]!=current_user.id.to_s
   end
 end


### PR DESCRIPTION
# What
ユーザーのシート一覧ページおよびシート表示ページでは、URLにパラメータを
直接指定すると飛べてしまう。これを回避するためリダイレクトを設定する

# Why
他のユーザーの一覧ページやシートが見えてしまうのは致命的なバグなため、早急な
修正が必要